### PR TITLE
Correcting  Full taxonomy doesn't work (issue #9 )

### DIFF
--- a/emapper2gbk/utils.py
+++ b/emapper2gbk/utils.py
@@ -278,7 +278,7 @@ def create_taxonomic_data_ete(species_name):
     taxons = species_name.split(";")
     for index, taxon in reversed(list(enumerate(taxons))):
         if not taxon:
-                continue
+            continue
         compatible_species_name = taxon.replace('/', '_')
         species_informations['description'] = compatible_species_name + ' genome'
         species_informations['organism'] = compatible_species_name

--- a/emapper2gbk/utils.py
+++ b/emapper2gbk/utils.py
@@ -207,8 +207,6 @@ def create_taxonomic_data(species_name):
 
     compatible_species_name = species_name.replace('/', '_')
 
-    species_name_url = species_name.replace(' ', '%20')
-
     if species_name == "bacteria":
         species_informations = {'db_xref': 'taxon:2', 'scientificName': 'Bacteria', 'commonName': 'eubacteria', 'formalName': 'false', 'rank': 'superkingdom', 'data_file_division': 'PRO', 'geneticCode': '11', 'submittable': 'false', 'description': 'bacteria genome', 'organism': 'bacteria', 'keywords': ['bacteria']} 
     elif species_name == "archaea":
@@ -222,7 +220,9 @@ def create_taxonomic_data(species_name):
     else:
         taxons = species_name.split(";")
         for index, taxon in reversed(list(enumerate(taxons))):
-            url = 'https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/scientific-name/' + taxon
+            compatible_species_name = taxon.replace('/', '_')
+            species_name_url = taxon.replace(' ', '%20')
+            url = 'https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/scientific-name/' + species_name_url
 
             try:
                 response = requests.get(url)
@@ -238,7 +238,7 @@ def create_taxonomic_data(species_name):
                 if index ==0:
                     logger.critical('/!\\ Error with {} this taxa has not been found in https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/scientific-name/'.format(species_name))
                     logger.critical('/!\\ Check the name of the taxa and its presence in the EBI taxonomy database.')
-                    logger.critical('/!\\ No genbank will be created for {}.'.format(species_name))
+                    logger.critical('/!\\ No genbank will be created for {}.'.format(taxon))
                     return None
                 else:
                     continue            
@@ -273,22 +273,27 @@ def create_taxonomic_data_ete(species_name):
         species_informations (dict): dictionary containing information about species
     """
     species_informations = {}
+    taxons = species_name.split(";")
+    for index, taxon in reversed(list(enumerate(taxons))):
+        compatible_species_name = taxon.replace('/', '_')
+        species_informations['description'] = compatible_species_name + ' genome'
+        species_informations['organism'] = compatible_species_name
+        species_informations['keywords'] = [compatible_species_name]
 
-    compatible_species_name = species_name.replace('/', '_')
-    species_informations['description'] = compatible_species_name + ' genome'
-    species_informations['organism'] = compatible_species_name
-    species_informations['keywords'] = [compatible_species_name]
-
-    ncbi = NCBITaxa()
-    species_taxids = ncbi.get_name_translator([species_name])
-    if species_name in species_taxids:
-        species_taxid = species_taxids[species_name][-1]
-        species_informations['db_xref'] = 'taxon:' + str(species_taxid)
-    else:
-        logger.critical('/!\\ Error with {} this taxa has not been found in ete3 NCBITaxa Database'.format(species_name))
-        logger.critical('/!\\ Check the name of the taxa and its presence in the NCBITaxa database.')
-        logger.critical('/!\\ No genbank will be created for {}.'.format(species_name))
-        return None
+        ncbi = NCBITaxa()
+        species_taxids = ncbi.get_name_translator([taxon])
+        if taxon in species_taxids:
+            species_taxid = species_taxids[taxon][-1]
+            species_informations['db_xref'] = 'taxon:' + str(species_taxid)
+            break
+        else:
+            if index ==0:
+                logger.critical('/!\\ Error with {} this taxa has not been found in ete3 NCBITaxa Database'.format(taxon))
+                logger.critical('/!\\ Check the name of the taxa and its presence in the NCBITaxa database.')
+                logger.critical('/!\\ No genbank will be created for {}.'.format(taxon))
+                return None
+            else:
+                continue
 
     return species_informations
 

--- a/emapper2gbk/utils.py
+++ b/emapper2gbk/utils.py
@@ -220,6 +220,9 @@ def create_taxonomic_data(species_name):
     else:
         taxons = species_name.split(";")
         for index, taxon in reversed(list(enumerate(taxons))):
+            if not taxon:
+                continue
+            
             compatible_species_name = taxon.replace('/', '_')
             species_name_url = taxon.replace(' ', '%20')
             url = 'https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/scientific-name/' + species_name_url

--- a/emapper2gbk/utils.py
+++ b/emapper2gbk/utils.py
@@ -220,22 +220,28 @@ def create_taxonomic_data(species_name):
     elif species_name == 'cellular organisms':
         species_informations = {'db_xref': 'taxon:131567', 'scientificName': 'cellular organisms', 'formalName': 'false', 'rank': 'no rank', 'division': 'UNC', 'geneticCode': '1', 'submittable': 'false'}
     else:
-        url = 'https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/scientific-name/' + species_name_url
+        taxons = species_name.split(";")
+        for index, taxon in reversed(list(enumerate(taxons))):
+            url = 'https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/scientific-name/' + taxon
 
-        try:
-            response = requests.get(url)
-        except requests.exceptions.ConnectionError:
-            logger.critical('/!\\ No internet connection, check the connection or use the --ete option (if you have the NCBITaxa database already downloaded).')
-            return None
+            try:
+                response = requests.get(url)
+            except requests.exceptions.ConnectionError:
+                logger.critical('/!\\ No internet connection, check the connection or use the --ete option (if you have the NCBITaxa database already downloaded).')
+                return None
 
-        # Check if there is taxonomy information in the EBI response JSON.
-        try:
-            temp_species_informations = response.json()[0]
-        except simplejson.errors.JSONDecodeError:
-            logger.critical('/!\\ Error with {} this taxa has not been found in https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/scientific-name/'.format(species_name))
-            logger.critical('/!\\ Check the name of the taxa and its presence in the EBI taxonomy database.')
-            logger.critical('/!\\ No genbank will be created for {}.'.format(species_name))
-            return None
+            # Check if there is taxonomy information in the EBI response JSON.
+            try:
+                temp_species_informations = response.json()[0]
+                break
+            except simplejson.errors.JSONDecodeError:
+                if index ==0:
+                    logger.critical('/!\\ Error with {} this taxa has not been found in https://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/scientific-name/'.format(species_name))
+                    logger.critical('/!\\ Check the name of the taxa and its presence in the EBI taxonomy database.')
+                    logger.critical('/!\\ No genbank will be created for {}.'.format(species_name))
+                    return None
+                else:
+                    continue            
 
         for temp_species_information in temp_species_informations:
             if temp_species_information == 'lineage':

--- a/tests/organism_names.tsv
+++ b/tests/organism_names.tsv
@@ -1,4 +1,4 @@
-gene_1781	Bacteria;Proteobacteria
-gene_1887	metagenome
-gene_2441	Archaea;Euryarchaeota;Archaeoglobi
-genes_3987_3988	cellular organisms
+gene_1781	Bacteria;Proteobacteria;;
+gene_1887	metagenome;
+gene_2441	Archaea;Euryarchaeota;Archaeoglobi;;
+genes_3987_3988	cellular organisms;

--- a/tests/organism_names.tsv
+++ b/tests/organism_names.tsv
@@ -1,4 +1,4 @@
-gene_1781	bacteria
+gene_1781	Bacteria;Proteobacteria
 gene_1887	metagenome
-gene_2441	archaea
+gene_2441	Archaea;Euryarchaeota;Archaeoglobi
 genes_3987_3988	cellular organisms

--- a/tests/test_emapper2gbk.py
+++ b/tests/test_emapper2gbk.py
@@ -35,6 +35,7 @@ ORG_NAME_ARCH = 'archaea'
 ORG_NAME_EUK = 'eukaryota'
 ORG_NAME_META = 'metagenome'
 ORG_NAME_CELL = 'cellular organisms'
+ORG_FULL_TAX = 'cellular organisms;Bacteria;Proteobacteria;Gammaproteobacteria;Enterobacterales;Enterobacteriaceae;Escherichia;Escherichia coli'
 ORG_FILE = 'organism_names.tsv'
 GO_FILE = 'go-basic.obo'
 
@@ -283,6 +284,24 @@ def test_gbk_genes_mode_test():
 
     return
 
+def test_gbk_genes_mode_lineage_test():
+    """Test genes mode with file as input and full lineage taxonomy.
+    """
+    print("*** Test genes mode with file as input and full lineage taxonomy ***")
+    gbk_test = 'test_no_gff.gbk'
+    gbk_creation(nucleic_fasta=FNA_INPUT,
+                protein_fasta=FAA_INPUT,
+                annot=ANNOT_INPUT,
+                org=ORG_FULL_TAX,
+                output_path=gbk_test,
+                gff=None,
+                gobasic=GO_FILE)
+
+    compare_two_gbks(EXPECTED_GBK_NO_GFF, gbk_test)
+    os.remove(gbk_test)
+
+    return
+
 
 def test_gbk_gene_mode_test_cli():
     """Test genes mode  with file as input.
@@ -343,6 +362,25 @@ def test_gbk_genomes_mode_test():
                 annot=GENOME_ANNOT_INPUT,
                 gff=GENOME_GFF_INPUT,
                 org=ORG_NAME_ARCH,
+                output_path=gbk_test,
+                gobasic=GO_FILE)
+
+    compare_two_gbks(EXPECTED_GBK_WITH_GFF, gbk_test)
+    os.remove(gbk_test)
+
+    return
+
+def test_gbk_genomes_mode_lineage_test():
+    """Test genomes mode with file as input and full lineage taxonomy.
+    """
+    print("*** Test genomes mode with file as input and full lineage taxonomy ***")
+    gbk_test = 'test_gff.gbk'
+
+    gbk_creation(nucleic_fasta=GENOME_FNA_INPUT,
+                protein_fasta=GENOME_FAA_INPUT,
+                annot=GENOME_ANNOT_INPUT,
+                gff=GENOME_GFF_INPUT,
+                org=ORG_FULL_TAX,
                 output_path=gbk_test,
                 gobasic=GO_FILE)
 
@@ -590,10 +628,12 @@ def test_gbk_genomes_mode_gmove_test_cli():
     
 if __name__ == "__main__":
     test_gbk_genes_mode_test()
+    test_gbk_genes_mode_lineage_test()
     test_gbk_gene_mode_test_cli()
     test_gbk_genes_mode_annot_v2()
     test_gbk_genes_mode_annot_v2_cli()
     test_gbk_genomes_mode_test()
+    test_gbk_genomes_mode_lineage_test()
     test_gbk_genomes_mode_test_cli()
     test_gbk_genomes_mode_folder()
     test_gbk_genomes_mode_folder_cli()


### PR DESCRIPTION
Correction for : Full taxonomy doesn't work (issue #9 )
These modifications works on cli mode, directory mode or file mode.
The taxonomy must be separated by ";" : Bacteria;Proteobacteria;Gammaproteobacteria;Enterobacterales;Pasteurellaceae;Haemophilus
The code check the last value, if the taxonomy is not found it will try with the previous value until getting to the first one
It is possible to have blank between two ";". If there is a blank it will get the previous value.
If all the taxonomy is not found : an error occur and the user is informed
Tests has been written too.
Thank you for reviewing it.